### PR TITLE
Support libusb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:latest
 
-RUN apt update && apt install -y crossbuild-essential-armhf
+RUN dpkg --add-architecture armhf
+RUN apt update && apt install -y crossbuild-essential-armhf libusb-1.0-0-dev:armhf
 
 ENV CC arm-linux-gnueabihf-gcc
 ENV CXX arm-linux-gnueabihf-g++


### PR DESCRIPTION
NFC readerをコンパイルできるようにクロスコンパイル用のライブラリのインストールを追加しました。